### PR TITLE
Support new Chess.com live game path

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -46,6 +46,7 @@
         "https://www.chess.com/live",
         "https://www.chess.com/play/computer",
         "https://www.chess.com/live/game/*",
+        "https://www.chess.com/game/live/*",
         "https://www.chess.com/daily/game/*",
         "http://www.chessgames.com/perl/chessgame*",
         "https://chess-db.com/public/game.jsp*",


### PR DESCRIPTION
The new Chess.com live games are under the "https://www.chess.com/game/live/1234567687" url. This adds that url to the list of matches.