### PR TITLE
Update chess.com in-game page url pattern

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -46,6 +46,7 @@
         "https://www.chess.com/game/computer/*",
         "https://www.chess.com/events/*/*",
         "https://www.chess.com/play/online",
+        "https://www.chess.com/game/*",
         "https://www.chessgames.com/perl/chessgame*",
         "https://chessgames.com/perl/chessgame*",
         "https://chess-db.com/public/game.jsp*",


### PR DESCRIPTION
In chess.com, it seem in-game page and archive game page have different url.

- in-game `https://www.chess.com/game/123596287744`
- archive game `https://www.chess.com/game/live/123596287744`

Currently, ext only works on arhive game page.
To fix this, I’ve updated the manifest.json to include the in-game URL pattern.

> Issue that problem mentioned
> https://github.com/ZeroSharp/Chess.com_Analysis_Chrome_extension/issues/17#issuecomment-2661153704

### problem ver.

https://github.com/user-attachments/assets/32d26cf8-9c8f-44ad-91d2-3a5143fb5f12

### fixed ver.

https://github.com/user-attachments/assets/a01d8e2c-22dd-4f78-922c-b41b09da4715


