### PR TITLE
Fix: Share button not found on non-English browser locales

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -4,7 +4,6 @@
   "manifest_version": 3,
   "description": "Opens PGN of a game from chess.com or chessgames.com in lichess.org analysis",
   "homepage_url": "http://www.zerosharp.com",
-  "update_url": "https://clients2.google.com/service/update2/crx",
   "icons": {
       "128": "icons/knight128.png",
       "16": "icons/knight16.png",

--- a/ext/src/bg/getpgn.js
+++ b/ext/src/bg/getpgn.js
@@ -192,20 +192,21 @@ async function openShareDialog() {
         await secondaryControlsButton.click()
     }
     var shareButton =
+        document.querySelector('[data-cy="sidebar-share-icon"]') || // Locale-independent selector (works in all languages)
         document.querySelector('[data-cy="analysis-secondary-controls-menu-open-share"]') || // New button nested in secondary controls menu
-        document.querySelector('button[aria-label="Share"]') || // New specific aria-label selector
-        document.querySelector('button.cc-icon-button-component[aria-label="Share"]') || // More specific cc-icon-button
+        document.querySelector('button[aria-label="Share"]') || // English aria-label
+        document.querySelector('button[aria-label="공유"]') || // Korean aria-label
+        document.querySelector('button.cc-icon-button-component[aria-label="Share"]') ||
         document.querySelector('span.secondary-controls-icon.download') ||
-        document.querySelector('button.share-button-component.icon-share') ||
         document.querySelector('button.share-button-component.icon-share') ||
         document.querySelector('button.icon-font-chess.share.live-game-buttons-button') ||
         document.querySelector('button.share-button-component.share') ||
         document.querySelector("button[data-test='download']") ||
-        document.querySelector("#shareMenuButton") ||
-        document.querySelector(".icon-font-chess.share.icon-font-primary") ||
-        document.querySelector(".icon-font-chess.share.game-buttons-icon") ||
-        document.querySelector(".icon-font-chess.share") ||
-        document.querySelector(".icon-share");
+        document.querySelector('#shareMenuButton') ||
+        document.querySelector('.icon-font-chess.share.icon-font-primary') ||
+        document.querySelector('.icon-font-chess.share.game-buttons-icon') ||
+        document.querySelector('.icon-font-chess.share') ||
+        document.querySelector('.icon-share');
     if (shareButton) {
         return new Promise((resolve) => {
             shareButton.click()


### PR DESCRIPTION
## Summary

- Fix "Share button not found" error on non-English browser locales
- Add locale-independent CSS selector as primary fallback
- Remove Chrome Web Store `update_url` for Edge compatibility

## Problem

`openShareDialog()` relies on `button[aria-label="Share"]`, but chess.com localizes `aria-label` based on browser locale (e.g. `"공유"` in Korean). All selectors miss.

## Changes

### 1. Locale-independent selector (`getpgn.js`)

Added `[data-cy="sidebar-share-icon"]` as the first selector. `data-cy` is not localized:

```js
var shareButton =
    document.querySelector('[data-cy="sidebar-share-icon"]') || // Locale-independent
    document.querySelector('[data-cy="analysis-secondary-controls-menu-open-share"]') ||
    document.querySelector('button[aria-label="Share"]') || // English
    document.querySelector('button[aria-label="공유"]') || // Korean
    // ... remaining fallbacks
```

### 2. Remove `update_url` (`manifest.json`)

Removed `"update_url": "https://clients2.google.com/service/update2/crx"` per [Microsoft's porting guide](https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/port-chrome-extension).

## Test plan

- [x] Tested on Edge (Korean locale) — confirmed working
- [x] Verified `[data-cy="sidebar-share-icon"]` exists on chess.com game pages